### PR TITLE
Resend sync request with each retry.

### DIFF
--- a/Source/ArduinoUploader/BootloaderProgrammers/Protocols/STK500v1/STK500v1BootloaderProgrammer.cs
+++ b/Source/ArduinoUploader/BootloaderProgrammers/Protocols/STK500v1/STK500v1BootloaderProgrammer.cs
@@ -15,12 +15,12 @@ namespace ArduinoUploader.BootloaderProgrammers.Protocols.STK500v1
 
         public override void EstablishSync()
         {
-            Send(new GetSyncRequest());
-
             const int maxRetries = 256;
             var retryCounter = 0;
             while (retryCounter++ < maxRetries)
             {
+                SerialPort.DiscardInBuffer();
+                Send(new GetSyncRequest());
                 var result = Receive<GetSyncResponse>();
                 if (result == null) continue;
                 if (result.IsInSync) break;


### PR DESCRIPTION
Fixes issue #28 
Clear the input buffer and resend the sync request with each sync retry for STK500v1.
This partially reverses the change to commit 7765e6d, but it brings it closer inline to what avrdude does.

This is the code from avrdude 6.3 for reference:

```
int stk500_getsync(PROGRAMMER * pgm)
{
  unsigned char buf[32], resp[32];
  int attempt;

  /*
   * get in sync */
  buf[0] = Cmnd_STK_GET_SYNC;
  buf[1] = Sync_CRC_EOP;
  
  /*
   * First send and drain a few times to get rid of line noise 
   */
   
  stk500_send(pgm, buf, 2);
  stk500_drain(pgm, 0);
  stk500_send(pgm, buf, 2);
  stk500_drain(pgm, 0);

  for (attempt = 0; attempt < MAX_SYNC_ATTEMPTS; attempt++) {
    stk500_send(pgm, buf, 2);
    stk500_recv(pgm, resp, 1);
    if (resp[0] == Resp_STK_INSYNC){
      break;
    }
    avrdude_message(MSG_INFO, "%s: stk500_getsync() attempt %d of %d: not in sync: resp=0x%02x\n",
                    progname, attempt + 1, MAX_SYNC_ATTEMPTS, resp[0]);
  }
  if (attempt == MAX_SYNC_ATTEMPTS) {
    stk500_drain(pgm, 0);
    return -1;
  }

  if (stk500_recv(pgm, resp, 1) < 0)
    return -1;
  if (resp[0] != Resp_STK_OK) {
    avrdude_message(MSG_INFO, "%s: stk500_getsync(): can't communicate with device: "
                    "resp=0x%02x\n",
                    progname, resp[0]);
    return -1;
  }

  return 0;
}
```

As you can see, it does a send-drain-send-drain then goes into a send-read loop. When I replicated this pattern exactly, the next read would timeout. I'm not sure what that's about - but a drain-send-read loop addresses the problem as far as my testing went.