### PR TITLE
Add Option to allow 32u4 NOT not be sent to bootloader mode.

### DIFF
--- a/Source/ArduinoUploader/ArduinoSketchUploader.cs
+++ b/Source/ArduinoUploader/ArduinoSketchUploader.cs
@@ -78,6 +78,7 @@ namespace ArduinoUploader
                 IMcu mcu;
 
                 var model = _options.ArduinoModel.ToString();
+
                 var hardwareConfig = ReadConfiguration();
                 var modelOptions = hardwareConfig.Arduinos.SingleOrDefault(
                     x => x.Model.Equals(model, StringComparison.OrdinalIgnoreCase));
@@ -100,10 +101,12 @@ namespace ArduinoUploader
                 var preOpenResetBehavior = ParseResetBehavior(modelOptions.PreOpenResetBehavior);
                 var postOpenResetBehavior = ParseResetBehavior(modelOptions.PostOpenResetBehavior);
                 var closeResetBehavior = ParseResetBehavior(modelOptions.CloseResetBehavior);
+                var triggerBootloader = (_options.TriggerBootloader) ? true : false;
+
 
                 var serialPortConfig = new SerialPortConfig(serialPortName,
                     modelOptions.BaudRate, preOpenResetBehavior, postOpenResetBehavior, closeResetBehavior,
-                    modelOptions.SleepAfterOpen, modelOptions.ReadTimeout, modelOptions.WriteTimeout);
+                    modelOptions.SleepAfterOpen, modelOptions.ReadTimeout, modelOptions.WriteTimeout, triggerBootloader);
 
                 switch (modelOptions.Protocol)
                 {

--- a/Source/ArduinoUploader/ArduinoSketchUploaderOptions.cs
+++ b/Source/ArduinoUploader/ArduinoSketchUploaderOptions.cs
@@ -9,5 +9,7 @@ namespace ArduinoUploader
         public string PortName { get; set; }
 
         public ArduinoModel ArduinoModel { get; set; }
+
+        public bool TriggerBootloader { get; set; }
     }
 }

--- a/Source/ArduinoUploader/BootloaderProgrammers/ResetBehavior/ResetThrough1200BpsBehavior.cs
+++ b/Source/ArduinoUploader/BootloaderProgrammers/ResetBehavior/ResetThrough1200BpsBehavior.cs
@@ -14,30 +14,36 @@ namespace ArduinoUploader.BootloaderProgrammers.ResetBehavior
             Logger?.Info("Issuing forced 1200bps reset...");
             var currentPortName = serialPort.PortName;
             var originalPorts = SerialPortStream.GetPortNames();
+            var newPort = currentPortName;
 
-            // Close port ...
-            serialPort.Close();
 
-            // And now open port at 1200 bps
-            serialPort = new SerialPortStream(currentPortName, 1200)
+            if (config.TriggerBootloader)
             {
-                Handshake = Handshake.DtrRts
-            };
-            serialPort.Open();
+                // Close port ...
+                serialPort.Close();
 
-            // Close and wait for a new virtual COM port to appear ...
-            serialPort.Close();
+                // And now open port at 1200 bps
+                serialPort = new SerialPortStream(currentPortName, 1200)
+                {
+                    Handshake = Handshake.DtrRts
+                };
+                serialPort.Open();
 
-            var newPort = WaitHelper.WaitFor(timeoutVirtualPortDiscovery, virtualPortDiscoveryInterval,
-                () => SerialPortStream.GetPortNames().Except(originalPorts).SingleOrDefault(),
-                (i, item, interval) =>
-                    item == null
-                        ? $"T+{i * interval} - Port not found"
-                        : $"T+{i * interval} - Port found: {item}");
+                // Close and wait for a new virtual COM port to appear ...
+                serialPort.Close();
 
-            if (newPort == null)
-                throw new ArduinoUploaderException(
-                    $"No (unambiguous) virtual COM port detected (after {timeoutVirtualPortDiscovery}ms).");
+                newPort = WaitHelper.WaitFor(timeoutVirtualPortDiscovery, virtualPortDiscoveryInterval,
+                    () => SerialPortStream.GetPortNames().Except(originalPorts).SingleOrDefault(),
+                    (i, item, interval) =>
+                        item == null
+                            ? $"T+{i * interval} - Port not found"
+                            : $"T+{i * interval} - Port found: {item}");
+
+                if (newPort == null)
+                    throw new ArduinoUploaderException(
+                        $"No (unambiguous) virtual COM port detected (after {timeoutVirtualPortDiscovery}ms).");
+            } 
+
 
             return new SerialPortStream
             {

--- a/Source/ArduinoUploader/BootloaderProgrammers/SerialPortConfig.cs
+++ b/Source/ArduinoUploader/BootloaderProgrammers/SerialPortConfig.cs
@@ -14,7 +14,8 @@ namespace ArduinoUploader.BootloaderProgrammers
             IResetBehavior closeResetAction,
             int sleepAfterOpen = 0,
             int readTimeout = DefaultTimeout,
-            int writeTimeout = DefaultTimeout)
+            int writeTimeout = DefaultTimeout,
+            bool triggerBootloader = true)
         {
             PortName = portName;
             BaudRate = baudRate;
@@ -24,6 +25,7 @@ namespace ArduinoUploader.BootloaderProgrammers
             SleepAfterOpen = sleepAfterOpen;
             ReadTimeOut = readTimeout;
             WriteTimeOut = writeTimeout;
+            TriggerBootloader = triggerBootloader;
         }
 
         public string PortName { get; set; }
@@ -34,5 +36,7 @@ namespace ArduinoUploader.BootloaderProgrammers
         public int SleepAfterOpen { get; set; }
         public int ReadTimeOut { get; set; }
         public int WriteTimeOut { get; set; }
+        public bool TriggerBootloader { get; set; }
+
     }
 }


### PR DESCRIPTION
this to allow 32u4 not running in serial mode to be programmed (user needs to manually switch to bootloader)

example: 32u4 as HID device, has no COM port to trigger the bootloader.